### PR TITLE
fix: Add API Error Handling with event validation

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="openjdk-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="openjdk-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/main/kotlin/com/github/coxwave/alignsdkkotlin/APIException.kt
+++ b/src/main/kotlin/com/github/coxwave/alignsdkkotlin/APIException.kt
@@ -1,3 +1,5 @@
 package com.github.coxwave.alignsdkkotlin
 
-class APIException(cause: Throwable?) : Exception(cause)
+import com.connectrpc.ConnectException
+
+class APIException(cause: ConnectException) : Exception("${cause.code}: ${cause.message}")

--- a/src/main/kotlin/com/github/coxwave/alignsdkkotlin/APIException.kt
+++ b/src/main/kotlin/com/github/coxwave/alignsdkkotlin/APIException.kt
@@ -1,0 +1,3 @@
+package com.github.coxwave.alignsdkkotlin
+
+class APIException(cause: Throwable?) : Exception(cause)

--- a/src/main/kotlin/com/github/coxwave/alignsdkkotlin/AlignAI.kt
+++ b/src/main/kotlin/com/github/coxwave/alignsdkkotlin/AlignAI.kt
@@ -3,6 +3,7 @@ package com.github.coxwave.alignsdkkotlin
 import com.github.coxwave.alignsdkkotlin.events.BaseEvent
 import build.buf.gen.ingestion.v1alpha.CollectEventsRequest
 import build.buf.gen.ingestion.v1alpha.IngestionServiceClient
+import com.connectrpc.Code
 import com.connectrpc.ProtocolClientConfig
 import com.connectrpc.extensions.GoogleJavaProtobufStrategy
 import com.connectrpc.impl.ProtocolClient
@@ -32,11 +33,18 @@ class AlignAI(
     suspend fun collectEvents(events: List<BaseEvent>) {
         val builder = CollectEventsRequest.newBuilder().setRequestId(UUID.randomUUID().toString().replace("-", ""))
         events.forEach { event -> builder.addEvents(event.asProtoEventBuilder().setProjectId(config.projectId)) }
-        ingestionClient.collectEvents(
+        val response = ingestionClient.collectEvents(
             builder.build(),
             mapOf(
                 "Authorization" to listOf("Bearer ${config.apiKey}")
             ),
         )
+        if (response.code == Code.OK) {
+            return
+        }
+
+        // Error handling
+        val cause = response.failure{ error -> error.cause }
+        throw APIException(cause)
     }
 }

--- a/src/main/kotlin/com/github/coxwave/alignsdkkotlin/AlignAI.kt
+++ b/src/main/kotlin/com/github/coxwave/alignsdkkotlin/AlignAI.kt
@@ -45,6 +45,6 @@ class AlignAI(
 
         // Error handling
         val cause = response.failure{ error -> error.cause }
-        throw APIException(cause)
+        throw APIException(cause!!)
     }
 }

--- a/src/main/kotlin/com/github/coxwave/alignsdkkotlin/events/CloseSessionEvent.kt
+++ b/src/main/kotlin/com/github/coxwave/alignsdkkotlin/events/CloseSessionEvent.kt
@@ -9,6 +9,11 @@ class CloseSessionEvent(
 ) : BaseEvent() {
     override var eventType = Constants.EVENT_CLOSE_SESSION
 
+    init {
+        require(sessionId.isNotBlank()) { "sessionId is required" }
+        require(sessionId.length <= 64) { "sessionId must be at most 64 characters" }
+    }
+
     override fun asProtoEventBuilder(): Event.Builder {
         val propsBuilder = EventProperties.SessionProperties.newBuilder()
             .setSessionId(sessionId)

--- a/src/main/kotlin/com/github/coxwave/alignsdkkotlin/events/CreateMessageEvent.kt
+++ b/src/main/kotlin/com/github/coxwave/alignsdkkotlin/events/CreateMessageEvent.kt
@@ -17,6 +17,13 @@ class CreateMessageEvent(
 ) : BaseEvent() {
     override var eventType = Constants.EVENT_CREATE_MESSAGE
 
+    init {
+        require(sessionId.isNotBlank()) { "sessionId is required" }
+        require(sessionId.length <= 64) { "sessionId must be at most 64 characters" }
+        require(messageIndex > 0u) { "messageIndex must be greater than 0" }
+        require(content.isNotBlank()) { "content is required" }
+    }
+
     override fun asProtoEventBuilder(): Event.Builder {
         val propsBuilder = EventProperties.MessageProperties.newBuilder()
             .setSessionId(sessionId)

--- a/src/main/kotlin/com/github/coxwave/alignsdkkotlin/events/IdentifyUserEvent.kt
+++ b/src/main/kotlin/com/github/coxwave/alignsdkkotlin/events/IdentifyUserEvent.kt
@@ -16,6 +16,14 @@ class IdentifyUserEvent(
 ): BaseEvent() {
     override var eventType = Constants.EVENT_IDENTIFY_USER
 
+    init {
+        require(userId.isNotBlank()) { "userId is required" }
+        require(userId.length <= 64) { "userId must be at most 64 characters" }
+        require(userDisplayName == null || userDisplayName.length <= 64) { "userDisplayName must be at most 64 characters" }
+        require(userEmail == null || userEmail.length <= 256) { "userEmail must be at most 256 characters" }
+        require(userCountryCode == null || userCountryCode.length == 2) { "userCountryCode must be ISO Alpha-2 code." }
+    }
+
     override fun asProtoEventBuilder(): Event.Builder {
         val propsBuilder = EventProperties.UserProperties.newBuilder().setUserId(userId)
         if (userDisplayName != null) {

--- a/src/main/kotlin/com/github/coxwave/alignsdkkotlin/events/OpenSessionEvent.kt
+++ b/src/main/kotlin/com/github/coxwave/alignsdkkotlin/events/OpenSessionEvent.kt
@@ -11,6 +11,15 @@ class OpenSessionEvent(
 ) : BaseEvent() {
     override var eventType = Constants.EVENT_OPEN_SESSION
 
+    init {
+        require(sessionId.isNotBlank()) { "sessionId is required" }
+        require(sessionId.length <= 64) { "sessionId must be at most 64 characters" }
+        require(userId.isNotBlank()) { "userId is required" }
+        require(userId.length <= 64) { "userId must be at most 64 characters" }
+        require(assistantId.isNotBlank()) { "assistantId is required" }
+        require(assistantId.length <= 64) { "assistantId must be at most 64 characters" }
+    }
+
     override fun asProtoEventBuilder(): Event.Builder {
         val propsBuilder = EventProperties.SessionProperties.newBuilder()
             .setSessionId(sessionId)


### PR DESCRIPTION
- Add `APIException` and throw it for unsuccessful response from API
- Add validation with `require` syntax on Event init